### PR TITLE
Fix OP_SIZE

### DIFF
--- a/build/script_interpreter/interpreter.js
+++ b/build/script_interpreter/interpreter.js
@@ -353,7 +353,7 @@ interpreter.prototype.nextStep = function (mainstack, altstack, script, index) {
 		case "OP_SIZE":
 			var size = mainstack.peek(1)
 			if (size == null) return -1;
-			size = size.length();
+			size = size.length / 2;
 			mainstack.push(size);
 			break;
 


### PR DESCRIPTION
size() is not a function, rather a variable.
it will count the characters, and not the hexadecimal size so divide by 2.

This will fail if the hexadecimal string is off by one character.