### PR TITLE
Support numbers as input for sha1

### DIFF
--- a/build/script_interpreter/sha1.js
+++ b/build/script_interpreter/sha1.js
@@ -24,6 +24,7 @@ var Sha1 = {};
  * @returns {string} Hash of msg as hex character string.
  */
 Sha1.hash = function(msg) {
+    msg = msg.toString(16);
     // convert string to UTF-8, as SHA only deals with byte-streams
     msg = msg.utf8Encode();
 


### PR DESCRIPTION
Without the change attempting `1 OP_SHA1` in the IDE will get stuck and yield
`Uncaught TypeError: msg.utf8Encode is not a function` in the console

The String conversion was taken from `Sha256.hash` which works fine https://github.com/siminchen/bitcoinIDE/blob/1cac29c3fd9d0a1a2a147db57aab663a332f0248/build/script_interpreter/sha256.js#L28

Thanks a bunch for the project 👍 